### PR TITLE
Fix issue with link in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ Red is in continuous development and new features get added all the time. Stay t
 
 * [How to install on Linux, general steps](/Red-Docs/red_install_linux/)
 
-* [Autorestarting (upstart)](/Red-Docs/red_guide_linux_upstart/)
+* [Autorestarting](/Red-Docs/red_guide_linux_autostart/)
 
 ### Mac
 


### PR DESCRIPTION
So when I made the changes with regards to autostarting on Linux, I kinda forgot to change the link on the very front page. This PR fixes that
