### PR TITLE
Specifying Python version on existing docs

### DIFF
--- a/red/red_guide_linux_autostart.md
+++ b/red/red_guide_linux_autostart.md
@@ -98,11 +98,11 @@ npm install pm2 -g
 
 Now we are going to use pm2 to launch Red
 
-`cd` into your Red's installation directory and find out the location of your Python installation by doing `which python3.5`
+`cd` into your Red's installation directory and find out the location of your Python installation by doing `which python3/3.5/3.6`
 
 Use the path that you got from the above command as the argument in the command shown below (no need for brackets)
 ```
-pm2 start red.py --name "Red-Discordbot" --interpreter <path to python 3.5/3.6> -- --no-prompt
+pm2 start red.py --name "Red-Discordbot" --interpreter <path to python 3/3.5/3.6> -- --no-prompt
 ```
 
 Verify that everything went fine with

--- a/red/red_install_ubuntu.md
+++ b/red/red_install_ubuntu.md
@@ -27,7 +27,7 @@ git clone -b develop --single-branch https://github.com/Twentysix26/Red-DiscordB
 
 ```
 cd Red-DiscordBot
-python3 launcher.py
+python3/3.5/3.6 launcher.py
 ```
 From there select ``Install requirements`` and select 1 or 2
 
@@ -39,12 +39,12 @@ Follow the guide [here](/Red-Docs/red_guide_bot_accounts/#creating-a-new-bot-acc
 
 Enter the bot directory and start the launcher, then select option 1 or 2 and follow the initial setup.
 ```
-python3 launcher.py
+python3/3.5/3.6 launcher.py
 ```
 
 ## Updating the bot
 
 To update the bot enter the bot directory and start the launcher,  then select ``Update`` and select 1, 2, or 3
 ```
-python3 launcher.py
+python3/3.5/3.6 launcher.py
 ```


### PR DESCRIPTION
 * Category: Guides
 * Subject: Specifying Python version on existing docs
 * Author: You

Some users may need to ensure that Python3.5+ is being used if its not used as their default.