### PR TITLE
Specify Python 3.5.4 to download for Windows

### DIFF
--- a/red/red_install_windows.md
+++ b/red/red_install_windows.md
@@ -8,7 +8,7 @@ description: A guide for installing Red on Windows
 
 ### Software
 
-- [Install Python](https://www.python.org/downloads/). Red **needs the latest 3.5.x**. **Avoid 3.6 for the time being as there are known installation issues with it**.  
+- [Install Python](https://www.python.org/downloads/release/python-354/). Red **needs the latest 3.5.x**. **Avoid 3.6 for the time being as there are known installation issues with it**.  
 ![](http://i.imgur.com/tTeIWaW.png)<br/><br/>
 - [Install Git](https://git-scm.com/download/win)  
 ![](http://i.imgur.com/guis7EE.png)  


### PR DESCRIPTION
Lots of people coming into #support on the main server that just download the first thing off the Python release list (3.7).

## Before PR
Please make sure that you've completed the following steps

 - [ ] Added frontmatter header to your doc based on [this guide](/README.MD)
 - [ ] Formatted the doc to fit jekyll requirements based on [this guide](/README.MD)
 - [ ] Added link to a sidebar based on [this guide](/README.MD)

None, as this was just a link change.

## Doc info
Please provide a required info on your PR

 * Category: Guides
 * Subject: Windows installation
 * Author: Twentysix26
 
There are currently three categories available: troubleshooting, guides and custom cog documentation, please specify one of those in the list above
Subject might be anything, but we recommend sticking to 3-4 words
