### PR TITLE
Add out of date warning and link to V3 Docs

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ type: homepage
 
 [<img src="https://discordapp.com/api/guilds/133049272517001216/widget.png?style=shield">](https://discord.gg/red)
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 Red is in continuous development and new features get added all the time. Stay tuned by [joining the official server](https://discord.gg/red)!
 
 ## Installation

--- a/red/red_install_alpine.md
+++ b/red/red_install_alpine.md
@@ -6,6 +6,8 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Alpine.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 This guide is aimed as installing Red on Alpine.
 
 {% include callout.html content="**Warning**: For safety reasons, DO NOT install Red with a root user. Instead, make a new one." type="danger" %}

--- a/red/red_install_archlinux.md
+++ b/red/red_install_archlinux.md
@@ -6,6 +6,8 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Archlinux.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 This guide is aimed as installing Red on Archlinux.
 
 {% include callout.html content="**Warning**: For safety reasons, DO NOT install Red with a root user. Instead, make a new one." type="danger" %}

--- a/red/red_install_centos.md
+++ b/red/red_install_centos.md
@@ -6,6 +6,8 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on CentOS.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 This guide is aimed as installing Red on CentOS 7.
 
 {% include callout.html content="**Warning**: For safety reasons, DO NOT install Red with a root user. Instead, make a new one." type="danger" %}

--- a/red/red_install_debian.md
+++ b/red/red_install_debian.md
@@ -6,6 +6,8 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Debian.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 This guide is aimed as installing Red on Debian 8.
 
 {% include callout.html content="**Warning**: For safety reasons, DO NOT install Red with a root user. Instead, make a new one." type="danger" %}

--- a/red/red_install_fedora.md
+++ b/red/red_install_fedora.md
@@ -6,6 +6,8 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Fedora.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 This guide is aimed as installing Red on Fedora 25.
 
 {% include callout.html content="**Warning**: For safety reasons, DO NOT install Red with a root user. Instead, make a new one." type="danger" %}

--- a/red/red_install_kali.md
+++ b/red/red_install_kali.md
@@ -5,6 +5,8 @@ permalink: /red_install_kali/
 last_updated: Aug 18, 2017
 description: A guide for installing Red on Kali Linux.
 ---
+
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
  
 This guide is aimed at installing Red on Kali Linux.
  

--- a/red/red_install_linux.md
+++ b/red/red_install_linux.md
@@ -7,6 +7,8 @@ toc: false
 description: A list of guides for installing on Linux.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 ## Alpine
 
 * [How to install on Alpine](/Red-Docs/red_install_alpine/)

--- a/red/red_install_mac.md
+++ b/red/red_install_mac.md
@@ -6,6 +6,8 @@ last_updated: May 19, 2016
 description: A guide for installing Red on Mac.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 Guide originally made by orels1
 
 #### Installation

--- a/red/red_install_opensuse.md
+++ b/red/red_install_opensuse.md
@@ -6,6 +6,8 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on OpenSUSE.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 This guide is aimed as installing Red on OpenSUSE 42.2.
 
 {% include callout.html content="**Warning**: For safety reasons, DO NOT install Red with a root user. Instead, make a new one." type="danger" %}

--- a/red/red_install_raspbian.md
+++ b/red/red_install_raspbian.md
@@ -7,6 +7,8 @@ toc: true
 description: A guide for installing Red on Raspbian.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 The installation on Raspbian differs quite a bit from the a traditional Linux installation.
 Due the fact that Raspbian does not natively support Python 3.5 (and above),
 and that Raspbian does not support Ffmpeg. In this guide there is a easy fix for all these problems.

--- a/red/red_install_ubuntu.md
+++ b/red/red_install_ubuntu.md
@@ -6,6 +6,8 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Ubuntu.
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 This guide is aimed as installing Red on Ubuntu 16.04.
 
 {% include callout.html content="**Warning**: For safety reasons, DO NOT install Red with a root user. Instead, make a new one." type="danger" %}

--- a/red/red_install_windows.md
+++ b/red/red_install_windows.md
@@ -6,6 +6,8 @@ last_updated: Aug 18, 2016
 description: A guide for installing Red on Windows
 ---
 
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+
 ### Software
 
 - Install Python 3.5.4. Direct links: [64bit](https://www.python.org/ftp/python/3.5.4/python-3.5.4-amd64.exe) / [32bit](https://www.python.org/ftp/python/3.5.4/python-3.5.4.exe).  


### PR DESCRIPTION
Sorry for not using the PR template but it was only applicable for new docs, not additions to existing ones.

Adds a warning to the index page and all install pages warning that the github.io site is for an old version of Red, and links to the V3 docs.

Changes can be previewed here: https://zephyrkul.github.io/Red-Docs/