### PR TITLE
Show modal about Red V2 reaching end-of-life (with link to V3 docs)

### DIFF
--- a/_includes/old_version_modal.html
+++ b/_includes/old_version_modal.html
@@ -1,0 +1,45 @@
+<div class="modal fade" id="old-version-modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <span style="font-size:18px;font-weight:500" class="modal-title">Red V2 has reached end of life</span>
+      </div>
+      <div class="modal-body">
+        <p>But don't worry! Red V3 is already here and you can install it using one of installation guides on <a href="https://red-discordbot.readthedocs.io/en/stable/">our new site!</a>
+      </div>
+      <div class="modal-footer" style="padding-top:14px;padding-bottom:10px">
+        <a class="btn btn-primary" href="https://red-discordbot.readthedocs.io/en/stable/" role="button">Go to Red V3 docs</a>
+        <button type="button" class="btn" data-dismiss="modal">Close</button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+<script type="text/javascript">
+  function setCookie(cname, cvalue, exhours) {
+    var d = new Date();
+    d.setTime(d.getTime() + (exhours*60*60*1000));
+    var expires = 'expires='+ d.toUTCString();
+    document.cookie = cname + '='+ cvalue + ';' + expires + ';path=/';
+  }
+
+  function getCookie(cname) {
+    var name = cname + '=';
+    var decodedCookie = decodeURIComponent(document.cookie);
+    var ca = decodedCookie.split(';');
+    for(var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) == ' ') {
+        c = c.substring(1);
+      }
+      if (c.indexOf(name) == 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if(!getCookie('modal-shown')) {
+    $('#old-version-modal').modal()
+    setCookie('modal-shown', 1, 24)
+  }
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,6 +52,7 @@
     </script>
     {% endif %}
 </head>
+{% include old_version_modal.html %}
 <body>
 {% include topnav.html %}
 <!-- Page Content -->

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ type: homepage
 
 [<img src="https://discordapp.com/api/guilds/133049272517001216/widget.png?style=shield">](https://discord.gg/red)
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 Red is in continuous development and new features get added all the time. Stay tuned by [joining the official server](https://discord.gg/red)!
 

--- a/red/red_install_alpine.md
+++ b/red/red_install_alpine.md
@@ -6,7 +6,7 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Alpine.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 This guide is aimed as installing Red on Alpine.
 

--- a/red/red_install_archlinux.md
+++ b/red/red_install_archlinux.md
@@ -6,7 +6,7 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Archlinux.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 This guide is aimed as installing Red on Archlinux.
 

--- a/red/red_install_centos.md
+++ b/red/red_install_centos.md
@@ -6,7 +6,7 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on CentOS.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 This guide is aimed as installing Red on CentOS 7.
 

--- a/red/red_install_debian.md
+++ b/red/red_install_debian.md
@@ -6,7 +6,7 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Debian.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 This guide is aimed as installing Red on Debian 8.
 

--- a/red/red_install_fedora.md
+++ b/red/red_install_fedora.md
@@ -6,7 +6,7 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Fedora.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 This guide is aimed as installing Red on Fedora 25.
 

--- a/red/red_install_kali.md
+++ b/red/red_install_kali.md
@@ -6,7 +6,7 @@ last_updated: Aug 18, 2017
 description: A guide for installing Red on Kali Linux.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
  
 This guide is aimed at installing Red on Kali Linux.
  

--- a/red/red_install_linux.md
+++ b/red/red_install_linux.md
@@ -7,7 +7,7 @@ toc: false
 description: A list of guides for installing on Linux.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 ## Alpine
 

--- a/red/red_install_mac.md
+++ b/red/red_install_mac.md
@@ -6,7 +6,7 @@ last_updated: May 19, 2016
 description: A guide for installing Red on Mac.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 Guide originally made by orels1
 

--- a/red/red_install_opensuse.md
+++ b/red/red_install_opensuse.md
@@ -6,7 +6,7 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on OpenSUSE.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 This guide is aimed as installing Red on OpenSUSE 42.2.
 

--- a/red/red_install_raspbian.md
+++ b/red/red_install_raspbian.md
@@ -7,7 +7,7 @@ toc: true
 description: A guide for installing Red on Raspbian.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 The installation on Raspbian differs quite a bit from the a traditional Linux installation.
 Due the fact that Raspbian does not natively support Python 3.5 (and above),

--- a/red/red_install_ubuntu.md
+++ b/red/red_install_ubuntu.md
@@ -6,7 +6,7 @@ last_updated: Mar 23, 2017
 description: A guide for installing Red on Ubuntu.
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 This guide is aimed as installing Red on Ubuntu 16.04.
 

--- a/red/red_install_windows.md
+++ b/red/red_install_windows.md
@@ -6,7 +6,7 @@ last_updated: Aug 18, 2016
 description: A guide for installing Red on Windows
 ---
 
-{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/v3-develop/)" type="danger" %}
+{% include callout.html content="⚠ **Warning!** ⚠ This site is for an out-of-date version of Red! If you are looking to install the latest version, please see [our new site!](https://red-discordbot.readthedocs.io/en/stable/)" type="danger" %}
 
 ### Software
 


### PR DESCRIPTION
Issue template seems to apply to new docs pages and this PR doesn't make a new docs page, just improves whole docs so that they will now show modal about Red V2 reaching end-of-life when they open the website. It's configured so that it won't show again in next 24 hours after last time it showed.
Here's how the modal looks on a page:
![chrome_2019-07-22_02-49-51](https://user-images.githubusercontent.com/6032823/61599772-540a2400-ac2c-11e9-8546-4f2bb93c0f64.png)

If text should be changed to something different, I can obviously do that.